### PR TITLE
Add instructions for each file to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# tabGPT
+
+_Use GPT to classify a bunch of your open tabs!_
+
+### bookmark_utils
+
+Parse bookmarks file to BookmarkFolder class and serialize to JSON. Print result to STDOUT.
+
+1. Export bookmarks to an HTML file. Instructions:
+    * [Firefox](https://support.mozilla.org/en-US/kb/export-firefox-bookmarks-to-backup-or-transfer)
+1. Run bookmark_utils
+
+    ```python bookmark_utils.py path/to/bookmarks.html```
+
+### preprocess_urls.py
+
+Process a file of URLs and print to stdout a file with the metadata. Input file should contain one URL per line.
+
+1. Export tabs to a file
+    * Firefox: use [Export Tab URLs](https://addons.mozilla.org/en-GB/firefox/addon/export-tabs-urls-and-titles/) extension
+1. Run preprocess_urls
+
+    ```python preprocess_urls.py path/to/tabs_file.txt --output_format=[json|yaml|yml]```
+
+### clasify_tabs
+
+Currently this file does not classify tabs. It generates the next tokens in a sequence.
+
+#### Input from command line
+
+1. Run classify_tabs
+
+    ```python3 classify_tabs.py gen "lorem ipsum"```
+
+#### Input from file
+
+1. Write some sample text to a file `temp.txt` in the project directory
+
+1. Run classify_tabs:
+
+   ```poetry run python classify_tabs.py gen_file```

--- a/preprocess_urls.py
+++ b/preprocess_urls.py
@@ -123,8 +123,13 @@ def get_url_meta(url: str) -> dict:
 # def gpt_classify_meta(meta: dict) -> list[str]:
 # 	"""classify URL meta using GPT-3. returns a list of tags"""
 
-def process_urls(file: str, format: typing.Literal['json', 'yaml', 'yml']) -> str:
-	"""process a file of URLs and print to stdout a yaml file with the meta data"""
+def process_urls(file: str, output_format: typing.Literal['json', 'yaml', 'yml']) -> str:
+	"""
+	Process a file of URLs and print to stdout a file with the metadata.
+	Parameters:
+		file (str): a file with 1 URL on each line
+		output_format: format to use when writing the output
+	"""
 	with open(file) as f:
 		urls: list[str] = [line.strip() for line in f.readlines()]
 	
@@ -135,9 +140,9 @@ def process_urls(file: str, format: typing.Literal['json', 'yaml', 'yml']) -> st
 		meta.append(get_url_meta(url))
 
 	# enforce this key order: url, title, headings
-	if format == 'json':
+	if output_format == 'json':
 		print(json.dumps(meta, indent="  "))
-	elif format in ['yaml', 'yml']:
+	elif output_format in ['yaml', 'yml']:
 		print(yaml.dump(meta, sort_keys=False))
 	
 


### PR DESCRIPTION
Some small docs improvements:
*  [Add instructions for each file to README](https://github.com/mivanit/tabGPT/commit/20ded58489cf44ec990f5b4a4fd4186c60a0146b)
* [Update variable name and docstring for readability](https://github.com/mivanit/tabGPT/commit/5b8e7355ab0e211a9e98d902a3a9dc19c8226781)

Probably best to merge #3, then resolve merge conflicts in the README before merging this