### PR TITLE
Add docstrings to classify_tabs.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/**
+prompt.txt
 venv/

--- a/classify_tabs.py
+++ b/classify_tabs.py
@@ -1,7 +1,4 @@
-# TODO: this is for an old version and no longer works -- some jax dependency issues? need to fix
-
 import typing
-import json
 
 import torch
 from transformers import AutoTokenizer, AutoModelForCausalLM  # type: ignore[import]
@@ -32,6 +29,22 @@ if not typing.TYPE_CHECKING:
 def generate_continuation(
     prompt: str, max_length: int = 5, stop_token: str | None = None
 ) -> str:
+    """Generate continuation text for a given prompt using a pre-trained LLM.
+
+    Args:
+        prompt (str): The prompt to generate text continuation from.
+        max_length (int, optional): The maximum length of the generated text.
+          Defaults to 5.
+        stop_token (str, optional): The token to stop generating text at.
+          Defaults to None.
+
+    Returns:
+        str: The generated text continuation for the prompt.
+
+    Example:
+        >>> generate_continuation("The sky is", max_length=10, stop_token=".")
+        'The sky is blue.'
+    """
     input_ids: torch.Tensor = TOKENIZER.encode(prompt, return_tensors="pt")
     generated_text_ids = MODEL.generate(
         input_ids=input_ids.to(device),
@@ -41,10 +54,11 @@ def generate_continuation(
     generated_text: str = TOKENIZER.decode(
         generated_text_ids[0], clean_up_tokenization_spaces=True
     )
-    post_prompt_text: str = generated_text[
-        len(TOKENIZER.decode(input_ids[0], clean_up_tokenization_spaces=True)) :
-    ]
-    return post_prompt_text[: post_prompt_text.find(stop_token) if stop_token else None]
+    prompt_stripped = TOKENIZER.decode(input_ids[0], clean_up_tokenization_spaces=True)
+    post_prompt_text: str = generated_text[len(prompt_stripped) :]
+
+    stop_index = post_prompt_text.find(stop_token) + 1 if stop_token else None
+    return post_prompt_text[:stop_index]
 
 
 def generate(prompt: str, max_length: int = 5, stop_token: str | None = None) -> str:
@@ -52,6 +66,27 @@ def generate(prompt: str, max_length: int = 5, stop_token: str | None = None) ->
 
 
 def get_logits_and_tokens(text: str):
+    """Get the logits and tokens for a given input text.
+
+    Args:
+        text (str): The input text.
+
+    Returns:
+        Tuple of (logits, tokens) for the input text.
+
+        logits (torch.Tensor): A tensor of logits for the input text, of shape
+          (x, y), where x is the number of logits and y is the size of the
+          vocab. The logit for the final token is ommitted (TODO: why?).
+        tokens (List[str]): A list of tokens for the input text.
+
+    Example:
+        >>> get_logits_and_tokens("hello, world!")
+        (tensor([[-34.7599, -32.6039, -34.7921,  ..., -46.8525, -46.5174, -35.0202],
+            [-64.8099, -62.6199, -63.4192,  ..., -69.6624, -67.5905, -62.8190],
+            [-51.3938, -51.6655, -51.3386,  ..., -61.4105, -58.3002, -52.3297]],
+            grad_fn=<SliceBackward0>), ['hello', ',', ' world', '!'])
+    """
+
     input_ids: torch.Tensor = TOKENIZER.encode(text, return_tensors="pt")
     tokens: list[str] = [TOKENIZER.decode([input_id]) for input_id in input_ids[0]]
     output = MODEL(input_ids.to(device))
@@ -63,6 +98,25 @@ def test_generation(
     max_length: int = 5,
     stop_token: str = "\n",
 ):
+    """Generate a continuation based on the EXAMPLE_PROMPT.
+
+    Print the following to stdout:
+      * The prompt plus continuation, up to [max_length] or [stop_token],
+        whichever comes first.
+      * The probability that the last token equals " negative".
+      * The probabiilty that the last token equals " positive".
+
+    Example:
+        >>> generate_tokens(
+                \"\"\"Horrible: negative\nGreat: positive\nBad:\"\"\",
+                max_length=5,
+                stop_token="\n"
+        )
+        tokens: ['Hor', 'rible', ':', ' negative', '\n', 'Great', ':',
+          ' positive', '\n', 'Bad', ':', ' negative', '\n']
+        negative prob: 0.00023237711866386235
+        positive prob: 7.43172422517091e-05
+    """
     example_gen: str = generate(
         EXAMPLE_PROMPT,
         max_length=max_length,
@@ -76,16 +130,17 @@ def test_generation(
     negative_prob = last_token_probs[TOKENIZER.encode(" negative")[0]]
     positive_prob = last_token_probs[TOKENIZER.encode(" positive")[0]]
 
-    print(
-        f"tokens: {tokens}\nnegative prob: {negative_prob}\npositive prob: {positive_prob}"
-    )
+    print(f"tokens: {tokens}")
+    print(f"negative prob: {negative_prob}")
+    print(f"positive prob: {positive_prob}")
 
 
 def test_generation_from_file(
-        filename: str = "temp.txt", 
-        max_length: int = 10, 
-        stop_token: str = "\n",
-    ):
+    filename: str = "prompt.txt",
+    max_length: int = 10,
+    stop_token: str = "\n",
+):
+    """Generate a continuation based on a prompt in a file."""
     with open(filename, "r") as f:
         prompt: str = f.read()
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = venv


### PR DESCRIPTION
I added docstrings to classify_tabs.py as I was reading through the code and understanding it. I also did some small refactors (mostly extracting variables) which I think make it more readable. 

I made one functional change: `generate_continuation` will now print the continuation up to and *including* the stop token. I think this makes more sense because it tells the user that the stop token was reached, but I can change it back if you disagree. 

There is one TODO in the docstrings, because I didn't understand why we don't return the last logit in `get_logits_and_tokens`. It seems like we do this to make it easier to get the logits for the last token in `test_generation`. However this would break down if we hit `max_length` instead of `stop_token`. 

As an aside, I think we should move the test functions into a test package so that they don't clutter up the main implementation. Let me know if you'd like me to do this. Maybe it's premature. 

I'm not sure whether we should merge this PR as I don't know if it adds value, but I thought I would raise the PR and let you decide. 